### PR TITLE
Removed deprecated rule definitions: typecheck-regexp, no-digest

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /**
  * Created by lucian on 07/09/15.
+ * Updated by nvaldes on 03/08/16.
  */
 
 'use strict';
@@ -38,7 +39,6 @@ module.exports = {
 		"angular/no-angular-mock": 0,
 		"angular/no-controller": 0,
 		"angular/no-cookiestore": 2,
-		"angular/no-digest": 2,
 		"angular/no-jquery-angularelement": 2,
 		"angular/no-private-call": 2,
 		"angular/no-service-method": 2,
@@ -52,7 +52,6 @@ module.exports = {
 		"angular/typecheck-function": 2,
 		"angular/typecheck-number": 2,
 		"angular/typecheck-object": 2,
-		"angular/typecheck-regexp": 2,
 		"angular/typecheck-string": 2,
 		"angular/watchers-execution": [0, "$digest"],
 		"angular/window-service": 2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-xo-angular",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ESLint shareable config for Angular to be used with eslint-config-xo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The rules above were deprecated in eslint-plugin-angular, so using your config caused undefined rule errors to throw.